### PR TITLE
Separate API_KEYS from API related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist/
 node_modules/
 bower_components/
 API_related/
+API_KEYS/

--- a/API_related_wo_Keys/API_Bing_txtToImgs.js
+++ b/API_related_wo_Keys/API_Bing_txtToImgs.js
@@ -1,0 +1,45 @@
+
+const API_KEYS = require('../API_KEYS/apiKeys');
+const bingAccKeys = API_KEYS.bingAccKeys;
+
+
+var Bing = require('node-bing-api')({ accKey: bingAccKeys });
+
+var textsToImgs = (fiveGuesses, sendResToClient) => {
+
+  var fiveGuessesAnd25Urls = [];
+  var asyncCount = 0;
+
+  fiveGuesses.forEach((text) => {
+
+    Bing.images(text, {count: 5}, function(error, res, body){
+      
+      var guess = text;
+      var urls = [];
+
+      var resultsFromBing = body.value;
+      resultsFromBing.forEach(function(data){
+        urls.push(data.thumbnailUrl)
+      })
+
+      var oneGuessAndFiveUrls = {
+        'guess': guess,
+        'urls': urls
+      };
+
+      fiveGuessesAnd25Urls.push(oneGuessAndFiveUrls);
+
+      asyncCount++;
+      if (asyncCount === fiveGuesses.length) {
+        console.log('-----');
+        console.log(fiveGuessesAnd25Urls);
+        sendResToClient(fiveGuessesAnd25Urls);
+        console.log('----');
+      }
+    });
+  });
+}
+
+module.exports = textsToImgs;
+
+

--- a/API_related_wo_Keys/API_GoogleCV_ImgToTxts.js
+++ b/API_related_wo_Keys/API_GoogleCV_ImgToTxts.js
@@ -1,0 +1,36 @@
+const request = require('request');
+
+const API_KEYS = require('../API_KEYS/apiKeys');
+const gVisionProjectId = API_KEYS.gVisionProjectId;
+
+const textsToImgs = require('./API_Bing_txtToImgs');
+
+var vision = require('@google-cloud/vision')({
+  projectId: gVisionProjectId,
+  keyFilename: __dirname + '/../API_keys/gVisionJsonApi.json'
+});
+
+// EXAMPLE URLS 
+// var imageUri = 'https://s4.favim.com/orig/48/puppy-lion-cute-Favim.com-445038.jpg';
+// var imageUri = 'http://www.ngkenya.com/thumbs/inve0080.jpg';
+
+var originImgToSimilarImgs = (imageUri, callback) => {
+
+  var image = { source: {imageUri: imageUri} }
+  
+  vision.labelDetection(image).then(response => {
+    var fiveGuesses = [];
+
+    response[0].labelAnnotations.forEach(function(resultsFromGoo) {
+      fiveGuesses.push(resultsFromGoo.description);
+    });
+
+    textsToImgs(fiveGuesses, callback);
+  }).catch(err => {
+    console.error('!!! ERR from GOOBLE CLOUD VISION API !!!');
+  });
+
+};
+
+module.exports = originImgToSimilarImgs;
+

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
 var express = require('express');
 var bodyParser = require('body-parser');
-var originImgToSimilarImgs =  require('../API_related/API_GoogleCV_ImgToTxts.js')
+var originImgToSimilarImgs =  require('../API_related_wo_Keys/API_GoogleCV_ImgToTxts.js')
 // var db = require('../database/index') //check with pav
 var request = require('request')
 var app = express();


### PR DESCRIPTION
I separated API keys from API related files.
Instead of putting entire API related file into .gitignore file,
I only put API keys into .gitignore file.

Below is the steps you should follow in order for API to work.
1. Do -------> git pull --rebase upstream
2. Create ---> "API_KEYS" directory
3. Create ---> "apiKeys.js" and inside of this file and then copy and paste the code below
```
const bingAccKeys = 'a44aa769c3534dd284dbcf271bf037de';
const gVisionProjectId = 'axial-totality-174223';

module.exports.bingAccKeys = bingAccKeys;
module.exports.gVisionProjectId = gVisionProjectId;
```
4. Move ----> .json file inside of the "API_related" directory to "API_KEYS" directory and then name that .json file as "gVisionJsonApi.json"

It is a lot of steps to follow, but I think storing the API keys in a separate folder is better than entirely .gitignoring the API related files.  